### PR TITLE
Update format of keyboard buttons to differentiate I and /

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,19 +109,19 @@ chmod +x noobs-term.sh
 
 ## Ubuntu
 
-1. Press *Ctrl* + *a*, then *I* to load tmux plugins
+1. Press `Ctrl` + `a`, then <kbd>I</kbd> to load tmux plugins
 2. In Gnome Terminal preferences, set Nord as your default profile
 3. Set an appropriate font (e.g. Inconsolata for Powerline)
 
 ## OSX
 
-1. Press *Ctrl* + *a*, then *I* to load tmux plugins
+1. Press `Ctrl` + `a`, then <kbd>I</kbd> to load tmux plugins
 2. In iTerm, set your color profile to Nord
 3. Set an appropriate font (e.g. Inconsolata for Powerline)
 
 ## Arch
 
-1. Press *Ctrl* + *a*, then *I* to load tmux plugins
+1. Press `Ctrl` + `a`, then <kbd>I</kbd> to load tmux plugins
 2. In Gnome Terminal preferences, set Nord as your default profile
 3. Set an appropriate font (e.g. Inconsolata for Powerline)
 


### PR DESCRIPTION
Using italics made the `I` character look like a forward slash. I've reformatted it as a `<kbd>` so it's easier to read. I also changed the `Ctrl` and `a` to a format that makes it clearer that they are keystrokes.